### PR TITLE
Luisspo - Changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@
 [![TypeScript](https://img.shields.io/badge/typescript-%23007acc.svg?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![NodeJS](https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![Express.js](https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB)](https://expressjs.com/)
-[![MongoDB](https://img.shields.io/badge/MongoDB-%234ea94b.svg?style=for-the-badge&logo=mongodb&logoColor=white)](https://www.mongodb.com/)
+[![PostgreSQL](https://img.shields.io/badge/postgresql-%23336791.svg?style=for-the-badge&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)](https://www.docker.com/)
-
 
 ---
 
@@ -43,7 +42,7 @@ We are a coordinated team working across different layers of the stack to delive
 | Member | Role | Contact | 
 | :--- | :--- | :--- | 
 | **Elena Quintes** | Frontend| UO269665@uniovi.es | 
-| **Luis Sánchez** | Frontend| UO277488@uniovi.es | 
+| **Luis Sánchez de Posada** | Frontend| UO277488@uniovi.es | 
 | **Marcos José Sánchez**| Backend | UO300022@uniovi.es | 
 | **David Alonso** | Frontend | UO300569@uniovi.es | 
 | **Ceyda Tolunay** | Backend | UO318869@uniovi.es | 


### PR DESCRIPTION
To start I structured this PR in Changes -> Why those changes in order for it to be "clearer" and explain my reasons. This Pull Request introduces a comprehensive overhaul of our root README.md. The goal is to transition from a basic project description to a professional Software Architecture showcase, prioritizing technical documentation accessibility (Arc42) and system transparency. 


## Why these changes?

### 1. High-Level Documentation Hierarchy (Arc42)
*   **Change:** Moved the Arc42 Documentation badge to the very top (header).
*   **Why:** In Software Architecture courses, the **Arc42 documentation is the most critical asset**. By placing it at the top of the hierarchy, we eliminate friction for professors and developers, ensuring that the system's design is the first thing they can access.

### 2. Architectural "Map" (Project Structure)
*   **Change:** Implemented a clean, visual folder tree using standard ASCII symbols and emojis.
*   **Why:** A simple list is hard to parse. This "tree" view provides an immediate mental model of how our services (Webapp, RestAPI, and the Rust Gamey engine) interact. It highlights our **Separation of Concerns**—a key requirement for this project.

### 3. Team Visualization (Contrib.rocks)
*   **Change:** Integrated a dynamic contributor avatar grid using `contrib.rocks`.
*   **Why:** While the "Meet the Team" table provides necessary academic details (emails/IDs), the avatar grid adds **visual social proof**. It shows a "living" project and gives immediate, clickable credit to everyone’s GitHub profiles in a modern, standard format used in major open-source repositories.

### 4. Technical Branding (Tech Stack Badges)
*   **Change:** Standardized tech stack icons for React, TypeScript, Rust, and Docker.
*   **Why:** It allows for a split-second technical audit. Anyone viewing the repo can instantly identify our environment without reading paragraphs of text.

## Summary of Updates
- [x] Added dynamic Typing SVG for project tagline.
- [x] Reorganized badges (SonarCloud, Build Status) into a centered, clean layout.
- [x] Added specific component breakdown for `webapp`, `restapi`, and `gamey`.
- [x] Updated local and Docker installation instructions for better UX.

## Preview results
*The new README features a centered header, a professional tech stack grid, and an automated contributor section at the footer.*


## Final Remark
*As said in class, on Thursday, consistency is important. In our "Project Structure" tree inside the README, we have:
├── 📁 restapi/ # Node.js + Express backend. However, in our "Components" section, we call it Users Service. Consider changing either one of them's naming. If the folder is called restapi, we should refer to it as the "RestAPI (Users Service)" so there is no confusion.*