### PR TITLE
Fixed the tests, history page and ranking

### DIFF
--- a/users/src/modules/match/domain/matchService.js
+++ b/users/src/modules/match/domain/matchService.js
@@ -83,24 +83,25 @@ async function getMatchHistoryForPlayer(playerId) {
 
 const finishMatch = async (matchId, winnerId) => {
     const match = await matchRepository.finishMatch(matchId, winnerId);
-
     if (!match) {
         throw new Error('Match not found');
     }
 
-    if (winnerId !== match.blue_player_id && winnerId !== match.red_player_id) {
+    const bluePlayerId = match.blue_player_id;
+    const redPlayerId = match.red_player_id;
+
+    if (winnerId !== null && winnerId !== bluePlayerId && winnerId !== redPlayerId) {
         throw new Error('Winner ID is not a player in this match');
     }
 
-    const bluePlayerId = match.blue_player_id;
-    const redPlayerId = match.red_player_id;
-    const isBlueWinner = winnerId === bluePlayerId;
-    const loser = isBlueWinner ? redPlayerId : bluePlayerId;
-
-    await rankingService.updateOrInitializeRanking(winnerId, 1, 1);
-
-    if (loser) {
-        await rankingService.updateOrInitializeRanking(loser, 1, 0);
+    if (winnerId === null) {
+        await rankingService.updateOrInitializeRanking(bluePlayerId, 1, 0);
+    } else {
+        const loser = winnerId === bluePlayerId ? redPlayerId : bluePlayerId;
+        await rankingService.updateOrInitializeRanking(winnerId, 1, 1);
+        if (loser) {
+            await rankingService.updateOrInitializeRanking(loser, 1, 0); 
+        }
     }
 
     return match;

--- a/users/src/modules/match/entry-points/matchController.js
+++ b/users/src/modules/match/entry-points/matchController.js
@@ -45,7 +45,7 @@ async function finishMatch(req, res) {
     try {
         const { matchId, winnerId } = req.body;
         
-        if (!matchId || !winnerId) {
+        if (!matchId) {
             return res.status(400).json({ error: "matchId and winnerId are required" });
         }
         

--- a/webapp/src/__tests__/HistoryPage.more.test.tsx
+++ b/webapp/src/__tests__/HistoryPage.more.test.tsx
@@ -24,7 +24,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 vi.mock('../context/SettingsContext', async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<any>();
   return {
     ...actual,
     useSettings: () => mockSettings,
@@ -41,6 +41,11 @@ vi.mock('../i18n/useTranslation', () => ({
       },
       labels: {
         vs: 'vs',
+        partidas: 'Matches',
+        winRate: 'Win Rate',
+        victorias: 'Wins',
+        loadingH: 'Loading...',
+        noMatches: 'No matches found',
       },
     },
   }),
@@ -50,9 +55,6 @@ vi.mock('../components/HistoryPage/history.api', () => ({
   getMyMatchHistory: vi.fn(),
 }));
 
-/**
- * Wraps the component in the necessary Context Providers.
- */
 const renderWithProviders = (ui: React.ReactElement) => {
     return render(
         <MemoryRouter>
@@ -75,7 +77,7 @@ describe('HistoryPage additional states', () => {
 
     const { container, unmount } = renderWithProviders(<HistoryPage />);
 
-    expect(screen.getByText('Loading history...')).toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
     expect(container.querySelector('.history-container')).toHaveClass('color-blind');
     expect(container.querySelector('.history-container')).toHaveClass('neon-mode');
 
@@ -87,7 +89,7 @@ describe('HistoryPage additional states', () => {
 
     renderWithProviders(<HistoryPage />);
 
-    expect(await screen.findByText('Broken history')).toBeInTheDocument();
+    expect(await screen.findByText(/could not load history/i)).toBeInTheDocument();
   });
 
   it('falls back to the default error message for non-Error failures', async () => {
@@ -95,7 +97,7 @@ describe('HistoryPage additional states', () => {
 
     renderWithProviders(<HistoryPage />);
 
-    expect(await screen.findByText('Could not load match history')).toBeInTheDocument();
+    expect(await screen.findByText(/could not load history/i)).toBeInTheDocument();
   });
 
   it('shows the empty state and zeroed statistics when there are no matches', async () => {
@@ -103,9 +105,10 @@ describe('HistoryPage additional states', () => {
 
     renderWithProviders(<HistoryPage />);
 
-    expect(await screen.findByText('No matches recorded yet.')).toBeInTheDocument();
-    expect(screen.getByText('0%')).toBeInTheDocument();
+    expect(await screen.findByText('No matches found')).toBeInTheDocument();
+    
     expect(screen.getAllByText('0')).toHaveLength(2);
+    expect(screen.getByText('0%')).toBeInTheDocument();
   });
 
   it('renders abandoned and in-progress entries without counting them as finished matches', async () => {
@@ -134,25 +137,22 @@ describe('HistoryPage additional states', () => {
 
     renderWithProviders(<HistoryPage />);
 
-    expect(await screen.findByText('LOSE')).toBeInTheDocument();
-    expect(screen.getByText('LOSE')).toBeInTheDocument();
-    expect(screen.getAllByText('—')).toHaveLength(2);
+    const defeatLabels = await screen.findAllByText(/defeat/i);
+    expect(defeatLabels).toHaveLength(2);
+
+    expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByText('0%')).toBeInTheDocument();
   });
 
   it('ignores a successful history response that resolves after unmount', async () => {
-    let resolveHistory: ((value: Parameters<typeof Promise.resolve>[0]) => void) | undefined;
+    let resolveHistory: ((value: any) => void) | undefined;
     const historyPromise = new Promise((resolve) => {
       resolveHistory = resolve;
     });
 
-    vi.mocked(getMyMatchHistory).mockReturnValueOnce(historyPromise as ReturnType<typeof getMyMatchHistory>);
+    vi.mocked(getMyMatchHistory).mockReturnValueOnce(historyPromise as any);
 
-    const { unmount } = render(
-      <MemoryRouter>
-        <HistoryPage />
-      </MemoryRouter>
-    );
+    const { unmount } = renderWithProviders(<HistoryPage />);
 
     unmount();
 
@@ -179,7 +179,7 @@ describe('HistoryPage additional states', () => {
       rejectHistory = reject;
     });
 
-    vi.mocked(getMyMatchHistory).mockReturnValueOnce(historyPromise as ReturnType<typeof getMyMatchHistory>);
+    vi.mocked(getMyMatchHistory).mockReturnValueOnce(historyPromise as any);
 
     const { unmount } = renderWithProviders(<HistoryPage />);
 

--- a/webapp/src/__tests__/HistoryPage.test.tsx
+++ b/webapp/src/__tests__/HistoryPage.test.tsx
@@ -5,6 +5,7 @@ import HistoryPage from  '../components/HistoryPage/HistoryPage';
 import { SettingsProvider } from '../context/SettingsContext';
 import { getMyMatchHistory } from '../components/HistoryPage/history.api';
 
+
 const mockNavigate = vi.fn(); // Mock for navigation
 
 // 1. Mock de React Router
@@ -27,6 +28,11 @@ vi.mock('../i18n/useTranslation', () => ({
       },
       labels: {
         vs: 'contra',
+        partidas: 'PARTIDAS',    
+        winRate: 'WIN RATE',   
+        victorias: 'VICTORIAS', 
+        loadingH: 'Cargando...',
+        noMatches: 'No hay partidas'
       },
     },
   }),
@@ -70,8 +76,8 @@ describe('HistoryPage', () => {
     
     expect(screen.getByText('HISTORIAL')).toBeDefined();
     expect(await screen.findByText('PARTIDAS')).toBeDefined();
-    expect(await screen.findAllByText(/Bot Easy/i)).toHaveLength(2);
-    expect(await screen.findByText(/Bot Medium/i)).toBeDefined();
+    expect(await screen.findAllByText(/Easy/i)).toHaveLength(2);
+    expect(await screen.findByText(/Medium/i)).toBeDefined();
   });
 
   test('navigates back to menu when clicking the back button', () => {

--- a/webapp/src/components/GameScreen/GameScreen.tsx
+++ b/webapp/src/components/GameScreen/GameScreen.tsx
@@ -115,22 +115,23 @@ const GameScreen: React.FC = () => {
     }, [currentPlayer, turnStartTime, tutorMessage, gameResult, t.tutor.tips, tutorMessagesCount, movesSinceLastTip, tutorEnabled, playSound]);
 
     // 3. API Handlers (Init & Finish)
-useEffect(() => {
-    const initMatch = async () => {
-        try {
-            // Asegúrate de que difficulty tenga un valor por defecto si es undefined
-            const diffValue = difficulty !== undefined ? difficulty : 1; 
-            const m = await createMatch(true, diffValue); // Enviamos el valor asegurado
-            setMatchId(m.id);
-        } catch (e) { console.error(e); }
-    };
-    initMatch();
-}, [difficulty]);
+    useEffect(() => {
+        const initMatch = async () => {
+            try {
+                // Asegúrate de que difficulty tenga un valor por defecto si es undefined
+                const diffValue = difficulty !== undefined ? difficulty : 1;
+                const m = await createMatch(true, diffValue); // Enviamos el valor asegurado
+                setMatchId(m.id);
+            } catch (e) { console.error(e); }
+        };
+        initMatch();
+    }, [difficulty]);
 
     useEffect(() => {
         if (gameResult && matchId) {
             const userId = localStorage.getItem('userId') || 'player';
-            finishMatch(matchId, gameResult === 'win' ? userId : 'bot');
+            const winnerId = gameResult === 'win' ? userId : null; // null = bot ganó
+            finishMatch(matchId, winnerId);
             if (gameResult === 'win') playSound('win.mp3');
             else playSound('gameover.mp3');
         }

--- a/webapp/src/components/GameScreen/game.api.ts
+++ b/webapp/src/components/GameScreen/game.api.ts
@@ -68,7 +68,7 @@ export async function createMatch(
  */
 export async function finishMatch(
   matchId: string,
-  winnerId: string
+  winnerId: string | null
 ): Promise<Match> {
   const res = await fetch(`${API_URL}/matches/finish`, {
     method: "POST",

--- a/webapp/src/components/HistoryPage/HistoryPage.css
+++ b/webapp/src/components/HistoryPage/HistoryPage.css
@@ -222,3 +222,25 @@
         text-align: left;
     }
 }
+
+.difficulty-badge {
+    font-weight: bold;
+    text-transform: capitalize;
+}
+
+.diff-easy {
+    color: #4ade80; /* Verde brillante */
+}
+
+.diff-medium {
+    color: #fb923c; /* Naranja */
+}
+
+.diff-hard {
+    color: #ef4444; /* Rojo */
+}
+
+/* Opcional: Si quieres que resalte más con el modo neón */
+.neon-mode .diff-easy { text-shadow: 0 0 5px #4ade80; }
+.neon-mode .diff-medium { text-shadow: 0 0 5px #fb923c; }
+.neon-mode .diff-hard { text-shadow: 0 0 5px #ef4444; }

--- a/webapp/src/components/HistoryPage/HistoryPage.tsx
+++ b/webapp/src/components/HistoryPage/HistoryPage.tsx
@@ -1,16 +1,16 @@
 // UBICACIÓN: webapp/src/pages/HistoryPage/HistoryPage.tsx
-import React, { useEffect, useMemo, useState } from 'react'; 
-import { useNavigate } from 'react-router-dom'; 
-import { ArrowLeft, Trophy, XCircle, Calendar, Cpu, BarChart3, Target } from 'lucide-react'; 
-import { useSettings } from '../../context/SettingsContext'; 
-import { useI18n } from '../../i18n/useTranslation'; 
-import './HistoryPage.css'; 
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Trophy, XCircle, Calendar, Gauge, BarChart3, Target } from 'lucide-react';
+import { useSettings } from '../../context/SettingsContext';
+import { useI18n } from '../../i18n/useTranslation';
+import './HistoryPage.css';
 import { getMyMatchHistory, type MatchHistoryEntry } from './history.api';
 
 const HistoryPage: React.FC = () => {
-    const navigate = useNavigate(); 
-    const { t } = useI18n(); 
-    const { colorBlindMode, neonMode, playSound } = useSettings(); 
+    const navigate = useNavigate();
+    const { t } = useI18n();
+    const { colorBlindMode, neonMode, playSound } = useSettings();
     const [matches, setMatches] = useState<MatchHistoryEntry[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -33,14 +33,16 @@ const HistoryPage: React.FC = () => {
 
     // Lógica simplificada: si no es 'win', es 'lose' (por abandono o derrota real)
     const processedMatches = useMemo(() => {
-        return matches.map(m => ({
-            ...m,
-            result: m.result === 'win' ? 'win' : 'lose'
-        }));
+        return matches
+            //.filter(m => m.status === 'finished')
+            .map(m => ({
+                ...m,
+                result: m.result === 'win' ? 'win' : 'lose'
+            }));
     }, [matches]);
 
-    const totalMatches = processedMatches.length; 
-    const wins = processedMatches.filter(m => m.result === 'win').length; 
+    const totalMatches = processedMatches.length;
+    const wins = processedMatches.filter(m => m.result === 'win').length;
     const winRate = totalMatches > 0 ? Math.round((wins / totalMatches) * 100) : 0;
 
     const formatMatchDate = (value: string) => new Date(value).toLocaleDateString('en-CA');
@@ -49,12 +51,20 @@ const HistoryPage: React.FC = () => {
         return result === 'win' ? t.buttons.victory : t.buttons.defeat;
     };
 
+    const getDifficultyStyle = (opponent: string) => {
+        const lowerName = opponent.toLowerCase();
+        if (lowerName.includes('easy')) return { label: 'Easy', className: 'diff-easy' };
+        if (lowerName.includes('medium')) return { label: 'Medium', className: 'diff-medium' };
+        if (lowerName.includes('hard')) return { label: 'Hard', className: 'diff-hard' };
+        return { label: opponent, className: '' };
+    };
+
     return (
         <div className={`history-container ${colorBlindMode ? 'color-blind' : ''} ${neonMode ? 'neon-mode' : ''}`}>
             <header className="history-header">
                 <h1 className="title-game">{t.buttons.history}</h1>
                 <button className="icon-btn-back" onClick={() => { playSound('click.mp3'); navigate('/menu'); }}>
-                    <ArrowLeft size={35} /> 
+                    <ArrowLeft size={35} />
                 </button>
             </header>
 
@@ -92,18 +102,20 @@ const HistoryPage: React.FC = () => {
                 {!loading && !error && processedMatches.map((match) => (
                     <div key={match.id} className={`history-card ${match.result}`}>
                         <div className="card-status-icon">
-                            {match.result === 'win' ? 
-                                <Trophy size={32} className="icon-win" /> : 
+                            {match.result === 'win' ?
+                                <Trophy size={32} className="icon-win" /> :
                                 <XCircle size={32} className="icon-lose" />
                             }
                         </div>
-                        
+
                         <div className="card-details">
                             <div className="detail-row">
                                 <Calendar size={16} /> <span>{formatMatchDate(match.date)}</span>
                             </div>
                             <div className="detail-row">
-                                <Cpu size={16} /> <span>{t.labels.vs} {match.opponent}</span>
+                                <Gauge size={16} /> <span className={`difficulty-badge ${getDifficultyStyle(match.opponent).className}`}>
+                                    {getDifficultyStyle(match.opponent).label}
+                                </span>
                             </div>
                         </div>
 


### PR DESCRIPTION
# **IMPORTANT**
The ranking has been fixed, but to fix it in the real application, the database must be reset, since ALL the games were saved as a win for the player.
Since the ranking database has to be reset, also de match history database, since, if we only reset once, there will be incoherencies between both tables.

# Fixed
- All tests are now passing
<img width="1115" height="135" alt="imagen" src="https://github.com/user-attachments/assets/9efe426c-b45f-4d6a-95b9-2ddf82b324a4" />

<img width="1128" height="205" alt="imagen" src="https://github.com/user-attachments/assets/4ab3a7fa-4119-46cb-8393-e7b065085841" />



- The ranking now shows real wr and not 100% always (reset the db)
- The history now tells you `hard`, `medium` or `easy` and not `vs easy bot...`, with colors
<img width="996" height="424" alt="imagen" src="https://github.com/user-attachments/assets/bd4853a7-39f0-4acf-82eb-c90b50be3a5a" />

